### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php" : "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*"
+        "phpunit/phpunit": "^6.4"
     },
     "autoload": {
         "psr-4": {

--- a/tests/AbbreviationParserTest.php
+++ b/tests/AbbreviationParserTest.php
@@ -2,9 +2,10 @@
 
 namespace Spatie\HtmlElement\Test;
 
+use PHPUnit\Framework\TestCase;
 use Spatie\HtmlElement\AbbreviationParser;
 
-class AbbreviationParserTest extends \PHPUnit_Framework_TestCase
+class AbbreviationParserTest extends TestCase
 {
     /** @test */
     function it_can_parse_a_plain_element()

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -2,9 +2,10 @@
 
 namespace Spatie\HtmlElement\Test;
 
+use PHPUnit\Framework\TestCase;
 use Spatie\HtmlElement\Attributes;
 
-class AttributesTest extends \PHPUnit_Framework_TestCase
+class AttributesTest extends TestCase
 {
     /** @test */
     public function it_starts_empty()

--- a/tests/Helpers/ArrTest.php
+++ b/tests/Helpers/ArrTest.php
@@ -2,9 +2,10 @@
 
 namespace Spatie\HtmlElement\Test\Helpers\Arr;
 
+use PHPUnit\Framework\TestCase;
 use Spatie\HtmlElement\Helpers\Arr;
 
-class ArrTest extends \PHPUnit_Framework_TestCase
+class ArrTest extends TestCase
 {
     /** @test */
     public function it_flattens_an_array()

--- a/tests/HtmlElementTest.php
+++ b/tests/HtmlElementTest.php
@@ -2,9 +2,10 @@
 
 namespace Spatie\HtmlElement\Test;
 
+use PHPUnit\Framework\TestCase;
 use Spatie\HtmlElement\HtmlElement;
 
-class HtmlElementTest extends \PHPUnit_Framework_TestCase
+class HtmlElementTest extends TestCase
 {
     /** @test */
     function it_parses_a_tag()


### PR DESCRIPTION
As we support `PHP 7`, I've updated our suite of tests to `PHPUnit 6`.