### PR TITLE
[IMPROVEMENT] Implicit div tag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ el('div.container > div.row > div.col-md-6', 'Hello world!'));
 </div>
 ```
 
+Limited support of [implicit tag names](https://docs.emmet.io/abbreviations/implicit-names/) (`div`s only):
+
+```php
+el('.container > .row > .col-md-6', 'Hello world!'));
+```
+```html
+<div class="container">
+  <div class="row">
+    <div class="col-md-6">
+      Hello world!
+    </div>
+  </div>
+</div>
+```
+
 Manually nested tags:
 
 ```php

--- a/src/AbbreviationParser.php
+++ b/src/AbbreviationParser.php
@@ -35,7 +35,7 @@ class AbbreviationParser
     {
         foreach ($this->explodeTag($tag) as $part) {
 
-            switch ($part[0]) {
+            switch ($part[0] ?? '') {
                 case '.':
                     $this->parseClass($part);
                     break;

--- a/src/HtmlElement.php
+++ b/src/HtmlElement.php
@@ -69,7 +69,7 @@ class HtmlElement
     {
         $parsed = AbbreviationParser::parse($abbreviation);
 
-        $this->element = $parsed['element'];
+        $this->element = $parsed['element'] ?: 'div';
 
         $this->attributes->addClass($parsed['classes']);
 

--- a/tests/HtmlElementTest.php
+++ b/tests/HtmlElementTest.php
@@ -166,4 +166,22 @@ class HtmlElementTest extends TestCase
             HtmlElement::render('div.container > div.row')
         );
     }
+
+    /** @test */
+    function it_expands_implicit_divs()
+    {
+        $this->assertEquals(
+            '<div class="classname"></div>',
+            HtmlElement::render('.classname')
+        );
+    }
+
+    /** @test */
+    function it_supports_nesteed_implicit_divs()
+    {
+        $this->assertEquals(
+            '<div class="container"><div class="row"></div></div>',
+            HtmlElement::render('.container > .row')
+        );
+    }
 }


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide]().
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I have added tests to prove that the code in this PR works.

---

### Description

Emmet has such handy thing in it's syntax: [Imlicit tag names](https://docs.emmet.io/abbreviations/implicit-names/). This PR adds a very limited support, only \<div\> tags for now.
