### PR TITLE
FIX: escape attribute value

### DIFF
--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -104,6 +104,7 @@ class Attributes
                 $attributeStrings[] = $attribute;
                 continue;
             }
+            $value = htmlspecialchars($value, ENT_COMPAT);
 
             $attributeStrings[] = "{$attribute}=\"{$value}\"";
         }


### PR DESCRIPTION
**[FIX]**  escape attribute value

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide]().
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I have added tests to prove that the code in this PR works.

---

Added attribute value escaping to avoid incorrect HTML syntax, e.g.:

The code `el('a', ['title' => '5" display'], '...')` provides a result:
- `<a title="5" display">...</a>` - before fix (_incorrect HTML syntax_)
- `<a title="5&quot; display">...</a>` - after fix