### PR TITLE
Add PHP 8.1 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [7.3, 7.4, 8.0]
+        php: [8.1, 8.0, 7.4, 7.3]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,12 @@
         }
     ],
     "require": {
-        "php" : "^7.3|^8.0"
+        "php": "^7.3|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "dms/phpunit-arraysubset-asserts": "^0.3.0",
-        "friendsofphp/php-cs-fixer": "^3.0",
-        "vimeo/psalm": "^4.8"
+        "dms/phpunit-arraysubset-asserts": "^0.3.1",
+        "vimeo/psalm": "^4.13"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR adds PHP 8.1 support to the tests workflow, bumps the dependency versions in `composer.json`, and removes the unusaed `php-cs-fixer` package.

_This repository needs its primary branch renamed from `master` to `main`._